### PR TITLE
fix: wrap `isImage` in a try-catch

### DIFF
--- a/.changeset/thirty-lizards-pull.md
+++ b/.changeset/thirty-lizards-pull.md
@@ -1,0 +1,5 @@
+---
+"rehype-image-caption": patch
+---
+
+Wrap isImage in a try-catch block

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,16 @@ import { visit } from "unist-util-visit";
  * @param node Node to check
  * @returns `true` if the node is an image, `false` otherwise
  */
-const isImage = (node: ElementContent): boolean =>
-    isElement(node, "img") || (node.type === "mdxJsxFlowElement" && ["astro-image", "img"].includes(node.name ?? ""));
-
+const isImage = (node: ElementContent): boolean => {
+    try {
+        if (node.type === "mdxJsxFlowElement" && ["astro-image", "img"].includes(node.name ?? "")) {
+            return true;
+        }
+        return isElement(node, "img");
+    } catch {
+        return false;
+    }
+};
 /**
  * `rehype` plugin to set captions for images in addition to alt text.
  * @returns Transformer


### PR DESCRIPTION
Instead of failing the whole code flow, just silently parse as `false` and skip the item